### PR TITLE
Sherlock fixes 

### DIFF
--- a/contracts/automatedTrigger/Bracket.sol
+++ b/contracts/automatedTrigger/Bracket.sol
@@ -147,8 +147,7 @@ contract Bracket is Ownable, IBracket, ReentrancyGuard, Pausable {
             performData,
             (MasterUpkeepData)
         );
-        uint96 orderIdFromSet = uint96(dataSet.at(data.pendingOrderIdx));
-        require(orderIdFromSet == data.orderId, "Order Fill Mismatch");
+        require(dataSet.contains(data.orderId), "order not active");
         Order memory order = orders[data.orderId];
 
         //deduce if we are filling stop or take profit

--- a/contracts/automatedTrigger/Bracket.sol
+++ b/contracts/automatedTrigger/Bracket.sol
@@ -34,7 +34,7 @@ contract Bracket is Ownable, IBracket, ReentrancyGuard, Pausable {
 
     modifier paysFee() {
         uint256 orderFee = MASTER.orderFee();
-        require(msg.value >= orderFee, "Insufficient funds for order fee");
+        require(msg.value == orderFee, "Insufficient funds for order fee");
         _;
         // Transfer the fee to the contract owner
         (bool success, ) = payable(address(MASTER)).call{value: orderFee}("");

--- a/contracts/automatedTrigger/IAutomation.sol
+++ b/contracts/automatedTrigger/IAutomation.sol
@@ -344,7 +344,6 @@ interface IOracleLess {
     ) external payable;
 
     function fillOrder(
-        uint96 pendingOrderIdx,
         uint96 orderId,
         address target,
         bytes calldata txData

--- a/contracts/automatedTrigger/OracleLess.sol
+++ b/contracts/automatedTrigger/OracleLess.sol
@@ -157,9 +157,7 @@ contract OracleLess is IOracleLess, Ownable, ReentrancyGuard, Pausable {
     ///@notice allow administrator to cancel any order
     ///@notice once cancelled, any funds associated with the order are returned to the order recipient
     ///@notice only pending orders can be cancelled
-    function adminCancelOrder(
-        uint96 orderId
-    ) external onlyOwner nonReentrant {
+    function adminCancelOrder(uint96 orderId) external onlyOwner nonReentrant {
         Order memory order = orders[orderId];
         _cancelOrder(order, true);
     }
@@ -200,7 +198,6 @@ contract OracleLess is IOracleLess, Ownable, ReentrancyGuard, Pausable {
     }
 
     function fillOrder(
-        uint96 pendingOrderIdx,
         uint96 orderId,
         address target,
         bytes calldata txData
@@ -208,10 +205,7 @@ contract OracleLess is IOracleLess, Ownable, ReentrancyGuard, Pausable {
         //validate target
         MASTER.validateTarget(target);
 
-        require(
-            orderId == uint96(dataSet.at(pendingOrderIdx)),
-            "Order Fill Mismatch"
-        );
+        require(dataSet.contains(orderId), "order not active");
 
         //fetch order
         Order memory order = orders[orderId];

--- a/contracts/automatedTrigger/OracleLess.sol
+++ b/contracts/automatedTrigger/OracleLess.sol
@@ -157,14 +157,11 @@ contract OracleLess is IOracleLess, Ownable, ReentrancyGuard, Pausable {
     ///@notice allow administrator to cancel any order
     ///@notice once cancelled, any funds associated with the order are returned to the order recipient
     ///@notice only pending orders can be cancelled
-    ///NOTE if @param refund is false, then the order's tokens will not be refunded and will be stuck on this contract possibly forever
-    ///@notice ONLY SET @param refund TO FALSE IN THE CASE OF A BROKEN ORDER CAUSING cancelOrder() TO REVERT
     function adminCancelOrder(
-        uint96 orderId,
-        bool refund
+        uint96 orderId
     ) external onlyOwner nonReentrant {
         Order memory order = orders[orderId];
-        _cancelOrder(order, refund);
+        _cancelOrder(order, true);
     }
 
     ///@notice only the order recipient can cancel their order

--- a/contracts/automatedTrigger/StopLimit.sol
+++ b/contracts/automatedTrigger/StopLimit.sol
@@ -378,14 +378,11 @@ contract StopLimit is Ownable, IStopLimit, ReentrancyGuard, Pausable {
     ///@notice allow administrator to cancel any order
     ///@notice once cancelled, any funds associated with the order are returned to the order recipient
     ///@notice only pending orders can be cancelled
-    ///NOTE if @param refund is false, then the order's tokens will not be refunded and will be stuck on this contract possibly forever
-    ///@notice ONLY SET @param refund TO FALSE IN THE CASE OF A BROKEN ORDER CAUSING cancelOrder() TO REVERT
     function adminCancelOrder(
-        uint96 orderId,
-        bool refund
+        uint96 orderId
     ) external onlyOwner nonReentrant {
         Order memory order = orders[orderId];
-        _cancelOrder(order, refund);
+        _cancelOrder(order, true);
     }
 
     ///@notice only the order recipient can cancel their order

--- a/contracts/libraries/FixedPointMathLib.sol
+++ b/contracts/libraries/FixedPointMathLib.sol
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.0;
+
+/// @notice Arithmetic library with operations for fixed-point numbers.
+/// @author Solmate (https://github.com/transmissions11/solmate/blob/main/src/utils/FixedPointMathLib.sol)
+/// @author Inspired by USM (https://github.com/usmfum/USM/blob/master/contracts/WadMath.sol)
+library FixedPointMathLib {
+    /*//////////////////////////////////////////////////////////////
+                    SIMPLIFIED FIXED POINT OPERATIONS
+    //////////////////////////////////////////////////////////////*/
+
+    uint256 internal constant MAX_UINT256 = 2**256 - 1;
+
+    uint256 internal constant WAD = 1e18; // The scalar of ETH and most ERC20s.
+
+    function mulWadDown(uint256 x, uint256 y) internal pure returns (uint256) {
+        return mulDivDown(x, y, WAD); // Equivalent to (x * y) / WAD rounded down.
+    }
+
+    function mulWadUp(uint256 x, uint256 y) internal pure returns (uint256) {
+        return mulDivUp(x, y, WAD); // Equivalent to (x * y) / WAD rounded up.
+    }
+
+    function divWadDown(uint256 x, uint256 y) internal pure returns (uint256) {
+        return mulDivDown(x, WAD, y); // Equivalent to (x * WAD) / y rounded down.
+    }
+
+    function divWadUp(uint256 x, uint256 y) internal pure returns (uint256) {
+        return mulDivUp(x, WAD, y); // Equivalent to (x * WAD) / y rounded up.
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    LOW LEVEL FIXED POINT OPERATIONS
+    //////////////////////////////////////////////////////////////*/
+
+    function mulDivDown(
+        uint256 x,
+        uint256 y,
+        uint256 denominator
+    ) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Equivalent to require(denominator != 0 && (y == 0 || x <= type(uint256).max / y))
+            if iszero(mul(denominator, iszero(mul(y, gt(x, div(MAX_UINT256, y)))))) {
+                revert(0, 0)
+            }
+
+            // Divide x * y by the denominator.
+            z := div(mul(x, y), denominator)
+        }
+    }
+
+    function mulDivUp(
+        uint256 x,
+        uint256 y,
+        uint256 denominator
+    ) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Equivalent to require(denominator != 0 && (y == 0 || x <= type(uint256).max / y))
+            if iszero(mul(denominator, iszero(mul(y, gt(x, div(MAX_UINT256, y)))))) {
+                revert(0, 0)
+            }
+
+            // If x * y modulo the denominator is strictly greater than 0,
+            // 1 is added to round up the division of x * y by the denominator.
+            z := add(gt(mod(mul(x, y), denominator), 0), div(mul(x, y), denominator))
+        }
+    }
+
+    function rpow(
+        uint256 x,
+        uint256 n,
+        uint256 scalar
+    ) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            switch x
+            case 0 {
+                switch n
+                case 0 {
+                    // 0 ** 0 = 1
+                    z := scalar
+                }
+                default {
+                    // 0 ** n = 0
+                    z := 0
+                }
+            }
+            default {
+                switch mod(n, 2)
+                case 0 {
+                    // If n is even, store scalar in z for now.
+                    z := scalar
+                }
+                default {
+                    // If n is odd, store x in z for now.
+                    z := x
+                }
+
+                // Shifting right by 1 is like dividing by 2.
+                let half := shr(1, scalar)
+
+                for {
+                    // Shift n right by 1 before looping to halve it.
+                    n := shr(1, n)
+                } n {
+                    // Shift n right by 1 each iteration to halve it.
+                    n := shr(1, n)
+                } {
+                    // Revert immediately if x ** 2 would overflow.
+                    // Equivalent to iszero(eq(div(xx, x), x)) here.
+                    if shr(128, x) {
+                        revert(0, 0)
+                    }
+
+                    // Store x squared.
+                    let xx := mul(x, x)
+
+                    // Round to the nearest number.
+                    let xxRound := add(xx, half)
+
+                    // Revert if xx + half overflowed.
+                    if lt(xxRound, xx) {
+                        revert(0, 0)
+                    }
+
+                    // Set x to scaled xxRound.
+                    x := div(xxRound, scalar)
+
+                    // If n is even:
+                    if mod(n, 2) {
+                        // Compute z * x.
+                        let zx := mul(z, x)
+
+                        // If z * x overflowed:
+                        if iszero(eq(div(zx, x), z)) {
+                            // Revert if x is non-zero.
+                            if iszero(iszero(x)) {
+                                revert(0, 0)
+                            }
+                        }
+
+                        // Round to the nearest number.
+                        let zxRound := add(zx, half)
+
+                        // Revert if zx + half overflowed.
+                        if lt(zxRound, zx) {
+                            revert(0, 0)
+                        }
+
+                        // Return properly scaled zxRound.
+                        z := div(zxRound, scalar)
+                    }
+                }
+            }
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        GENERAL NUMBER UTILITIES
+    //////////////////////////////////////////////////////////////*/
+
+    function sqrt(uint256 x) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let y := x // We start y at x, which will help us make our initial estimate.
+
+            z := 181 // The "correct" value is 1, but this saves a multiplication later.
+
+            // This segment is to get a reasonable initial estimate for the Babylonian method. With a bad
+            // start, the correct # of bits increases ~linearly each iteration instead of ~quadratically.
+
+            // We check y >= 2^(k + 8) but shift right by k bits
+            // each branch to ensure that if x >= 256, then y >= 256.
+            if iszero(lt(y, 0x10000000000000000000000000000000000)) {
+                y := shr(128, y)
+                z := shl(64, z)
+            }
+            if iszero(lt(y, 0x1000000000000000000)) {
+                y := shr(64, y)
+                z := shl(32, z)
+            }
+            if iszero(lt(y, 0x10000000000)) {
+                y := shr(32, y)
+                z := shl(16, z)
+            }
+            if iszero(lt(y, 0x1000000)) {
+                y := shr(16, y)
+                z := shl(8, z)
+            }
+
+            // Goal was to get z*z*y within a small factor of x. More iterations could
+            // get y in a tighter range. Currently, we will have y in [256, 256*2^16).
+            // We ensured y >= 256 so that the relative difference between y and y+1 is small.
+            // That's not possible if x < 256 but we can just verify those cases exhaustively.
+
+            // Now, z*z*y <= x < z*z*(y+1), and y <= 2^(16+8), and either y >= 256, or x < 256.
+            // Correctness can be checked exhaustively for x < 256, so we assume y >= 256.
+            // Then z*sqrt(y) is within sqrt(257)/sqrt(256) of sqrt(x), or about 20bps.
+
+            // For s in the range [1/256, 256], the estimate f(s) = (181/1024) * (s+1) is in the range
+            // (1/2.84 * sqrt(s), 2.84 * sqrt(s)), with largest error when s = 1 and when s = 256 or 1/256.
+
+            // Since y is in [256, 256*2^16), let a = y/65536, so that a is in [1/256, 256). Then we can estimate
+            // sqrt(y) using sqrt(65536) * 181/1024 * (a + 1) = 181/4 * (y + 65536)/65536 = 181 * (y + 65536)/2^18.
+
+            // There is no overflow risk here since y < 2^136 after the first branch above.
+            z := shr(18, mul(z, add(y, 65536))) // A mul() is saved from starting z at 181.
+
+            // Given the worst case multiplicative error of 2.84 above, 7 iterations should be enough.
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+
+            // If x+1 is a perfect square, the Babylonian method cycles between
+            // floor(sqrt(x)) and ceil(sqrt(x)). This statement ensures we return floor.
+            // See: https://en.wikipedia.org/wiki/Integer_square_root#Using_only_integer_division
+            // Since the ceil is rare, we save gas on the assignment and repeat division in the rare case.
+            // If you don't care whether the floor or ceil square root is returned, you can remove this statement.
+            z := sub(z, lt(div(x, z), z))
+        }
+    }
+
+    function unsafeMod(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Mod x by y. Note this will return
+            // 0 instead of reverting if y is zero.
+            z := mod(x, y)
+        }
+    }
+
+    function unsafeDiv(uint256 x, uint256 y) internal pure returns (uint256 r) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Divide x by y. Note this will return
+            // 0 instead of reverting if y is zero.
+            r := div(x, y)
+        }
+    }
+
+    function unsafeDivUp(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Add 1 to x * y if x % y > 0. Note this will
+            // return 0 instead of reverting if y is zero.
+            z := add(gt(mod(x, y), 0), div(x, y))
+        }
+    }
+}

--- a/scripts/fillOrder.ts
+++ b/scripts/fillOrder.ts
@@ -327,7 +327,7 @@ const fillOracleLessOrder = async (signer: Signer) => {
                 await oracleLess.getAddress(),
                 order.minAmountOut
             )
-            await oracleLess.fillOrder(i, order.orderId, s.router02, txData)
+            await oracleLess.fillOrder(order.orderId, s.router02, txData)
             console.log(`Filled ${order.orderId} ${await tokenIn.symbol()} => ${await tokenOut.symbol()}`)
             //need to end loop, as the array idxs will be messed up if trying to fill multiple orders in one loop
             break

--- a/test/triggerV2/bracketEdgeCases.ts
+++ b/test/triggerV2/bracketEdgeCases.ts
@@ -481,7 +481,7 @@ describe("Bracket Contract Edge Cases", () => {
         it("Should allow admin to cancel order with refund", async () => {
             const initialBalance = await s.WETH.balanceOf(await s.Gary.getAddress())
 
-            await s.Bracket.connect(s.Frank).adminCancelOrder(orderId, true)
+            await s.Bracket.connect(s.Frank).adminCancelOrder(orderId)
 
             const finalBalance = await s.WETH.balanceOf(await s.Gary.getAddress())
             expect(finalBalance).to.eq(initialBalance + testAmount)
@@ -490,39 +490,9 @@ describe("Bracket Contract Edge Cases", () => {
             expect(pendingOrders.find(order => order.orderId === orderId)).to.be.undefined
         })
 
-        it("Should allow admin to cancel order without refund", async () => {
-            // Create another order
-            await s.WETH.connect(s.Gary).approve(await s.Bracket.getAddress(), testAmount)
-            await s.Bracket.connect(s.Gary).createOrder(
-                "0x",
-                currentPrice + ethers.parseUnits("100", 8),
-                currentPrice - ethers.parseUnits("100", 8),
-                testAmount,
-                await s.WETH.getAddress(),
-                await s.USDC.getAddress(),
-                await s.Gary.getAddress(),
-                100,
-                500,
-                500,
-                
-                "0x",
-                { value: s.fee }
-            )
-
-            const filter = s.Bracket.filters.BracketOrderCreated
-            const events = await s.Bracket.queryFilter(filter, -1)
-            const newOrderId = events[0].args[0]
-
-            const initialBalance = await s.WETH.balanceOf(await s.Gary.getAddress())
-
-            await s.Bracket.connect(s.Frank).adminCancelOrder(newOrderId, false) // No refund
-
-            const finalBalance = await s.WETH.balanceOf(await s.Gary.getAddress())
-            expect(finalBalance).to.eq(initialBalance) // No change in balance
-        })
 
         it("Should revert when non-admin tries to admin cancel", async () => {
-            await expect(s.Bracket.connect(s.Bob).adminCancelOrder(1, true))
+            await expect(s.Bracket.connect(s.Bob).adminCancelOrder(1))
                 .to.be.revertedWith("Ownable: caller is not the owner")
         })
     })

--- a/test/triggerV2/happyPath.ts
+++ b/test/triggerV2/happyPath.ts
@@ -1070,7 +1070,7 @@ describe("Oracle Less", () => {
             await s.OracleLess.getAddress(),
             0n//pendingOrders[0].minAmountOut//5600885752
         )
-        expect(s.OracleLess.fillOrder(0n, orderId, s.router02, txData)).to.be.revertedWith("Too Little Received")
+        expect(s.OracleLess.fillOrder(orderId, s.router02, txData)).to.be.revertedWith("Too Little Received")
 
         //reset
         await s.WETH.connect
@@ -1101,7 +1101,7 @@ describe("Oracle Less", () => {
             pendingOrders[0].minAmountOut
         )
 
-        await s.OracleLess.fillOrder(0n, orderId, s.router02, txData)
+        await s.OracleLess.fillOrder(orderId, s.router02, txData)
     })
 
 })

--- a/test/triggerV2/oracleAndPricing.ts
+++ b/test/triggerV2/oracleAndPricing.ts
@@ -151,8 +151,7 @@ describe("Oracle and Pricing Edge Cases", () => {
                 0 // 0% slippage
             )
             // 3000 USDC @ $1 = $3000, $3000 / $3000 = 1 WETH (18 decimals)
-            // Allow for small rounding differences in decimal conversions
-            expect(minAmount).to.be.closeTo(ethers.parseEther("1"), ethers.parseEther("0.001"))
+            expect(minAmount).to.eq(ethers.parseEther("1"))
         })
 
         it("Should handle same decimal tokens", async () => {
@@ -409,7 +408,7 @@ describe("Oracle and Pricing Edge Cases", () => {
                 const result = await s.Master.checkUpkeep("0x")
                 // If it doesn't revert, it should still work logically
                 expect(result.upkeepNeeded).to.be.true // Max price should trigger take profit
-            } catch (error) {
+            } catch (error: any) {
                 // Overflow is acceptable behavior
                 expect(error.message).to.include("overflow")
             }
@@ -446,9 +445,12 @@ describe("Oracle and Pricing Edge Cases", () => {
                 const rate = await s.Master.getExchangeRate(await s.USDC.getAddress(), testToken1)
                 // If it doesn't revert, the rate should be very large
                 expect(rate).to.be.gt(ethers.parseUnits("1000000", 8))
-            } catch (error) {
-                // Division by zero is acceptable behavior
-                expect(error.message).to.include("division by zero")
+            } catch (error: any) {
+                // Division by zero or invalid price is acceptable behavior
+                expect(error.message).to.satisfy((msg: string) => 
+                    msg.includes("division by zero") || 
+                    msg.includes("Invalid priceOut")
+                )
             }
         })
     })
@@ -482,7 +484,7 @@ describe("Oracle and Pricing Edge Cases", () => {
                 const rate = await s.Master.getExchangeRate(testToken1, testToken2)
                 // If successful, rate should be very large
                 expect(rate).to.be.gt(ethers.parseUnits("1000000", 8))
-            } catch (error) {
+            } catch (error: any) {
                 // Overflow protection is acceptable
                 expect(error.message).to.include("overflow")
             }

--- a/test/triggerV2/oracleLessComprehensive.ts
+++ b/test/triggerV2/oracleLessComprehensive.ts
@@ -671,23 +671,15 @@ describe("OracleLess Contract Comprehensive Tests", () => {
         it("Should allow admin to cancel order with refund", async () => {
             const initialBalance = await s.WETH.balanceOf(await s.Gary.getAddress())
 
-            await s.OracleLess.connect(s.Frank).adminCancelOrder(orderId, true)
+            await s.OracleLess.connect(s.Frank).adminCancelOrder(orderId)
 
             const finalBalance = await s.WETH.balanceOf(await s.Gary.getAddress())
             expect(finalBalance).to.eq(initialBalance + testAmount)
         })
 
-        it("Should allow admin to cancel order without refund", async () => {
-            const initialBalance = await s.WETH.balanceOf(await s.Gary.getAddress())
-
-            await s.OracleLess.connect(s.Frank).adminCancelOrder(orderId, false)
-
-            const finalBalance = await s.WETH.balanceOf(await s.Gary.getAddress())
-            expect(finalBalance).to.eq(initialBalance) // No refund
-        })
 
         it("Should revert when non-admin tries to admin cancel", async () => {
-            await expect(s.OracleLess.connect(s.Bob).adminCancelOrder(orderId, true))
+            await expect(s.OracleLess.connect(s.Bob).adminCancelOrder(orderId))
                 .to.be.revertedWith("Ownable: caller is not the owner")
         })
     })

--- a/test/triggerV2/oracleLessComprehensive.ts
+++ b/test/triggerV2/oracleLessComprehensive.ts
@@ -500,8 +500,7 @@ describe("OracleLess Contract Comprehensive Tests", () => {
                 expectedAmountOut / 2n
             )
 
-            const orderIndex = await findOrderIndex(orderId)
-            await expect(s.OracleLess.fillOrder(orderIndex, orderId, invalidTarget, txData))
+            await expect(s.OracleLess.fillOrder(orderId, invalidTarget, txData))
                 .to.be.revertedWith("Target !Valid")
         })
 
@@ -516,10 +515,9 @@ describe("OracleLess Contract Comprehensive Tests", () => {
                 expectedAmountOut / 2n
             )
 
-            // Use a valid index but wrong order ID to test ID mismatch
-            const orderIndex = await findOrderIndex(orderId)
-            await expect(s.OracleLess.fillOrder(orderIndex, 999999n, s.router02, txData))
-                .to.be.revertedWith("Order Fill Mismatch")
+            // Use a wrong order ID to test order not active
+            await expect(s.OracleLess.fillOrder(999999n, s.router02, txData))
+                .to.be.revertedWith("order not active")
         })
 
         it("Should revert when minimum amount not received", async () => {
@@ -547,8 +545,7 @@ describe("OracleLess Contract Comprehensive Tests", () => {
                 0n // Don't enforce minimum in swap
             )
 
-            const orderIndex = await findOrderIndex(orderId)
-            await expect(s.OracleLess.fillOrder(orderIndex, orderId, s.router02, txData))
+            await expect(s.OracleLess.fillOrder(orderId, s.router02, txData))
                 .to.be.revertedWith("Too Little Received")
         })
 
@@ -566,8 +563,7 @@ describe("OracleLess Contract Comprehensive Tests", () => {
                 0n // Set to 0 for swap, order has its own minimum
             )
 
-            const orderIndex = await findOrderIndex(orderId)
-            await s.OracleLess.fillOrder(orderIndex, orderId, s.router02, txData)
+            await s.OracleLess.fillOrder(orderId, s.router02, txData)
 
             // Check order was removed
             const pendingOrders = await s.OracleLess.getPendingOrders()
@@ -737,10 +733,7 @@ describe("OracleLess Contract Comprehensive Tests", () => {
                 expectedAmountOut
             )
 
-            const orderIndex = await findOrderIndex(orderId)
-            expect(orderIndex).to.not.eq(-1, "Order should exist in pending orders")
-            
-            await expect(s.OracleLess.fillOrder(orderIndex, orderId, s.router02, txData))
+            await expect(s.OracleLess.fillOrder(orderId, s.router02, txData))
                 .to.be.revertedWithCustomError(s.OracleLess, "EnforcedPause")
 
             await s.OracleLess.connect(s.Frank).pause(false)
@@ -804,13 +797,8 @@ describe("OracleLess Contract Comprehensive Tests", () => {
                 0n // Set to 0 for swap, order has its own minimum
             )
 
-            // Find the correct pending order index for this orderId
-            const pendingOrders = await s.OracleLess.getPendingOrders()
-            const orderIndex = pendingOrders.findIndex(order => order.orderId === orderId)
-            expect(orderIndex).to.not.eq(-1, "Order should exist in pending orders")
-
             // This should work normally
-            await s.OracleLess.fillOrder(orderIndex, orderId, s.router02, txData)
+            await s.OracleLess.fillOrder(orderId, s.router02, txData)
         })
     })
 })

--- a/test/triggerV2/securityAndAccessControl.ts
+++ b/test/triggerV2/securityAndAccessControl.ts
@@ -67,7 +67,7 @@ describe("Security and Access Control Tests", () => {
             it("Should restrict admin functions to owner", async () => {
                 const unauthorizedUser = s.Bob
 
-                await expect(s.Bracket.connect(unauthorizedUser).adminCancelOrder(1, true))
+                await expect(s.Bracket.connect(unauthorizedUser).adminCancelOrder(1))
                     .to.be.revertedWith("Ownable: caller is not the owner")
             })
 
@@ -89,7 +89,7 @@ describe("Security and Access Control Tests", () => {
             it("Should restrict admin functions to owner", async () => {
                 const unauthorizedUser = s.Bob
 
-                await expect(s.StopLimit.connect(unauthorizedUser).adminCancelOrder(1, true))
+                await expect(s.StopLimit.connect(unauthorizedUser).adminCancelOrder(1))
                     .to.be.revertedWith("Ownable: caller is not the owner")
             })
 
@@ -108,7 +108,7 @@ describe("Security and Access Control Tests", () => {
                 await expect(s.OracleLess.connect(unauthorizedUser).whitelistTokens([], []))
                     .to.be.revertedWith("Ownable: caller is not the owner")
 
-                await expect(s.OracleLess.connect(unauthorizedUser).adminCancelOrder(1, true))
+                await expect(s.OracleLess.connect(unauthorizedUser).adminCancelOrder(1))
                     .to.be.revertedWith("Ownable: caller is not the owner")
             })
 
@@ -771,7 +771,7 @@ describe("Security and Access Control Tests", () => {
             await s.Master.connect(s.Frank).pauseAll(true)
 
             // Admin should still be able to cancel orders
-            await s.Bracket.connect(s.Frank).adminCancelOrder(orderId, true)
+            await s.Bracket.connect(s.Frank).adminCancelOrder(orderId)
 
             // Unpause
             await s.Master.connect(s.Frank).pauseAll(false)

--- a/test/triggerV2/securityAndAccessControl.ts
+++ b/test/triggerV2/securityAndAccessControl.ts
@@ -354,12 +354,7 @@ describe("Security and Access Control Tests", () => {
             const maliciousTarget = await s.Bob.getAddress()
             const txData = "0x12345678" // Arbitrary call data
 
-            // Find the correct pending order index for this orderId
-            const pendingOrders = await s.OracleLess.getPendingOrders()
-            const orderIndex = pendingOrders.findIndex(order => order.orderId === orderId)
-            expect(orderIndex).to.not.eq(-1, "Order should exist in pending orders")
-
-            await expect(s.OracleLess.fillOrder(orderIndex, orderId, maliciousTarget, txData))
+            await expect(s.OracleLess.fillOrder(orderId, maliciousTarget, txData))
                 .to.be.revertedWith("Target !Valid")
         })
 
@@ -381,13 +376,8 @@ describe("Security and Access Control Tests", () => {
                 0n // Set to 0 for swap, order has its own minimum
             )
 
-            // Find the correct pending order index for this orderId
-            const pendingOrders = await s.OracleLess.getPendingOrders()
-            const orderIndex = pendingOrders.findIndex(order => order.orderId === orderId)
-            expect(orderIndex).to.not.eq(-1, "Order should exist in pending orders")
-
             // This should work with whitelisted target
-            await s.OracleLess.fillOrder(orderIndex, orderId, s.router02, txData)
+            await s.OracleLess.fillOrder(orderId, s.router02, txData)
         })
     })
 

--- a/test/triggerV2/stopLimitEdgeCases.ts
+++ b/test/triggerV2/stopLimitEdgeCases.ts
@@ -677,7 +677,7 @@ describe("StopLimit Contract Edge Cases", () => {
             orderId = events[0].args[0]
         })
 
-        it("Should revert when order ID mismatch", async () => {
+        it("Should revert when order ID doesn't exist", async () => {
             // Set price to trigger
             await s.wethOracle.setPrice(currentPrice - ethers.parseUnits("99", 8))
 
@@ -704,7 +704,7 @@ describe("StopLimit Contract Edge Cases", () => {
                 ]]
             )
 
-            await expect(s.StopLimit.performUpkeep(badData)).to.be.revertedWith("Order Fill Mismatch")
+            await expect(s.StopLimit.performUpkeep(badData)).to.be.revertedWith("order not active")
         })
 
         it("Should revert when order not in range", async () => {

--- a/test/triggerV2/stopLimitEdgeCases.ts
+++ b/test/triggerV2/stopLimitEdgeCases.ts
@@ -804,7 +804,7 @@ describe("StopLimit Contract Edge Cases", () => {
         it("Should allow admin to cancel order with refund", async () => {
             const initialBalance = await s.WETH.balanceOf(await s.Oscar.getAddress())
 
-            await s.StopLimit.connect(s.Frank).adminCancelOrder(orderId, true)
+            await s.StopLimit.connect(s.Frank).adminCancelOrder(orderId)
 
             const finalBalance = await s.WETH.balanceOf(await s.Oscar.getAddress())
             expect(finalBalance).to.eq(initialBalance + testAmount)
@@ -813,40 +813,9 @@ describe("StopLimit Contract Edge Cases", () => {
             expect(pendingOrders.find(order => order.orderId === orderId)).to.be.undefined
         })
 
-        it("Should allow admin to cancel order without refund", async () => {
-            // Create another order
-            await s.WETH.connect(s.Oscar).approve(await s.StopLimit.getAddress(), testAmount)
-            await s.StopLimit.connect(s.Oscar).createOrder(
-                currentPrice - ethers.parseUnits("100", 8),
-                currentPrice + ethers.parseUnits("200", 8),
-                currentPrice - ethers.parseUnits("200", 8),
-                testAmount,
-                await s.WETH.getAddress(),
-                await s.USDC.getAddress(),
-                await s.Oscar.getAddress(),
-                100,
-                500,
-                500,
-                500,
-                false,
-                "0x",
-                { value: s.fee }
-            )
-
-            const filter = s.StopLimit.filters.StopLimitOrderCreated
-            const events = await s.StopLimit.queryFilter(filter, -1)
-            const newOrderId = events[0].args[0]
-
-            const initialBalance = await s.WETH.balanceOf(await s.Oscar.getAddress())
-
-            await s.StopLimit.connect(s.Frank).adminCancelOrder(newOrderId, false) // No refund
-
-            const finalBalance = await s.WETH.balanceOf(await s.Oscar.getAddress())
-            expect(finalBalance).to.eq(initialBalance) // No change in balance
-        })
 
         it("Should revert when non-admin tries to admin cancel", async () => {
-            await expect(s.StopLimit.connect(s.Bob).adminCancelOrder(1, true))
+            await expect(s.StopLimit.connect(s.Bob).adminCancelOrder(1))
                 .to.be.revertedWith("Ownable: caller is not the owner")
         })
     })


### PR DESCRIPTION
#103 Precision Loss issue
In order to keep the complexity of fixes low, we are opting to keep the existing math as is

The precision loss is still valid, as we cannot have 100% perfect precision due to external oracle prices being in 1e8 terms. 

The existing math truncates when it does loose precision, which is good as it ensures that we will not have any solvency issues, but it does mean that dust will still accumulate over time

To mitigate this, we opted to add a simple sweepDust function to Bracket
This can only be called by the owner and only when there are 0 pending orders, and will allow any dust to be removed from the contract by the admins

However, this introduced a vector for admins / compromised admin wallet to steal user funds when combined with the admin cancel order w/o refund, so this functionality was removed. 

It is our opinion that the cancel w/o refund is not needed anymore, we can skip over any stuck or stale orders in checkUpkeep

Now there the added benefit that there is no path for funds to become permanently stuck on the contract


Additionally, we have adjusted the order of operations in the minAmountReceived calculation in order to avoid the double division. This seems to have mitigated the issue, and dust accumulation due to precision loss is now exceptionally minimal. 
